### PR TITLE
feat: ルールベース査定ロジックの完全削除（MLモデル専用化）

### DIFF
--- a/valuation-api-ml/main_ml.py
+++ b/valuation-api-ml/main_ml.py
@@ -122,7 +122,7 @@ async def get_model_info():
     """
     try:
         info = {
-            "model_type": "LightGBM" if ML_AVAILABLE else "Rule-based",
+            "model_type": "LightGBM" if ML_AVAILABLE else "ML (Lightweight)",
             "is_trained": valuation_model.is_trained,
             "ml_available": ML_AVAILABLE,
             "features": getattr(valuation_model, 'feature_columns', None)

--- a/valuation-api-ml/models/lightweight_model.py
+++ b/valuation-api-ml/models/lightweight_model.py
@@ -1,6 +1,6 @@
 """
 機械学習モデル専用査定システム
-MLモデルが必須
+MLモデルが必須 - ルールベース査定は削除済み
 """
 import json
 from typing import Dict, List, Optional
@@ -50,7 +50,8 @@ class LightweightValuationModel:
                 self.ml_available = True
                 logger.info("ML model loaded successfully")
             else:
-                logger.info("ML model files not found, using rule-based calculation")
+                logger.error("ML model files not found - ML model is required")
+                raise FileNotFoundError("ML model files (valuation_model.joblib, label_encoders.joblib) not found")
         except Exception as e:
             logger.warning(f"Failed to load ML model: {e}")
     
@@ -117,7 +118,8 @@ class LightweightValuationModel:
         try:
             # MLモデルが利用可能でない場合はエラー
             if not self.ml_available or self.ml_model is None:
-                raise ValueError("ML model is not available. Please ensure model files are present.")
+                logger.error("ML model is not available")
+                raise RuntimeError("ML model is not loaded. Cannot perform valuation.")
             
             # MLモデルによる予測
             estimated_price = self._ml_predict(

--- a/valuation-api-ml/models/ml_valuation_model.py
+++ b/valuation-api-ml/models/ml_valuation_model.py
@@ -24,17 +24,6 @@ class MLValuationModel:
             'total_area', 'building_ratio', 'age_squared'
         ]
         
-        # 東京23区の基準価格（フォールバック用）
-        self.ward_base_prices = {
-            '千代田区': 250, '中央区': 200, '港区': 220,
-            '新宿区': 150, '文京区': 140, '台東区': 120,
-            '墨田区': 100, '江東区': 110, '品川区': 160,
-            '目黒区': 170, '大田区': 130, '世田谷区': 140,
-            '渋谷区': 180, '中野区': 120, '杉並区': 130,
-            '豊島区': 140, '北区': 100, '荒川区': 90,
-            '板橋区': 100, '練馬区': 110, '足立区': 80,
-            '葛飾区': 85, '江戸川区': 90
-        }
         
         self._load_model()
     
@@ -50,7 +39,8 @@ class MLValuationModel:
                 self.is_trained = True
                 logger.info("ML model loaded successfully")
             else:
-                logger.warning("ML model files not found, will use fallback method")
+                logger.error("ML model files not found - ML model is required")
+                raise FileNotFoundError("ML model files (valuation_model.joblib, label_encoders.joblib) not found")
                 
         except Exception as e:
             logger.error(f"Failed to load ML model: {e}")
@@ -105,30 +95,6 @@ class MLValuationModel:
             logger.error(f"Feature preparation failed: {e}")
             raise
     
-    def _fallback_prediction(self, prefecture: str, city: str, district: str,
-                           land_area: float, building_area: float, building_age: int) -> Dict[str, Any]:
-        """MLモデルが使用できない場合のフォールバック予測"""
-        logger.info("Using fallback rule-based prediction")
-        
-        # 基準価格を取得
-        base_price_per_sqm = self.ward_base_prices.get(city, 100)
-        
-        # 土地価格計算
-        land_price = land_area * base_price_per_sqm
-        
-        # 建物価格計算（築年数による減価）
-        building_depreciation = max(0.3, 1 - (building_age * 0.03))
-        building_price = building_area * base_price_per_sqm * 0.8 * building_depreciation
-        
-        # 総価格
-        total_price = (land_price + building_price) * 10000  # 万円から円に変換
-        
-        # 市場変動（±5%）
-        import random
-        variation = random.uniform(0.95, 1.05)
-        estimated_price = total_price * variation
-        
-        return estimated_price
     
     def predict(self, prefecture: str, city: str, district: str,
                 land_area: float, building_area: float, building_age: int) -> Dict[str, Any]:
@@ -147,30 +113,20 @@ class MLValuationModel:
             予測結果の辞書
         """
         try:
-            if self.is_trained and self.model is not None:
-                # ML予測を試行
-                try:
-                    X = self._prepare_features(prefecture, city, district, 
-                                             land_area, building_area, building_age)
-                    estimated_price = self.model.predict(X)[0]
-                    
-                    # 信頼度計算（MLモデルベース）
-                    confidence = max(75, min(95, 90 - building_age * 0.3))
-                    
-                    logger.info(f"ML prediction: ¥{estimated_price:,.0f}")
-                    
-                except Exception as e:
-                    logger.warning(f"ML prediction failed: {e}, using fallback")
-                    estimated_price = self._fallback_prediction(
-                        prefecture, city, district, land_area, building_area, building_age
-                    )
-                    confidence = max(70, min(85, 85 - building_age * 0.5))
-            else:
-                # フォールバック予測
-                estimated_price = self._fallback_prediction(
-                    prefecture, city, district, land_area, building_area, building_age
-                )
-                confidence = max(70, min(85, 85 - building_age * 0.5))
+            # MLモデルが利用可能かチェック
+            if not self.is_trained or self.model is None:
+                logger.error("ML model is not available")
+                raise RuntimeError("ML model is not loaded. Cannot perform valuation.")
+            
+            # ML予測を実行
+            X = self._prepare_features(prefecture, city, district, 
+                                     land_area, building_area, building_age)
+            estimated_price = self.model.predict(X)[0]
+            
+            # 信頼度計算（MLモデルベース）
+            confidence = max(75, min(95, 90 - building_age * 0.3))
+            
+            logger.info(f"ML prediction: ¥{estimated_price:,.0f}")
             
             # 価格帯計算
             price_range = {
@@ -179,12 +135,7 @@ class MLValuationModel:
             }
             
             # 査定要因分析
-            factors = []
-            
-            if self.is_trained:
-                factors.append("機械学習モデルによる高精度予測")
-            else:
-                factors.append("ルールベース予測（MLモデル未利用）")
+            factors = ["機械学習モデルによる高精度予測"]
             
             if building_age <= 5:
                 factors.append("築浅物件で、価格にプラス影響")

--- a/valuation-api/main_ml.py
+++ b/valuation-api/main_ml.py
@@ -122,7 +122,7 @@ async def get_model_info():
     """
     try:
         info = {
-            "model_type": "LightGBM" if ML_AVAILABLE else "Rule-based",
+            "model_type": "LightGBM" if ML_AVAILABLE else "ML (Lightweight)",
             "is_trained": valuation_model.is_trained,
             "ml_available": ML_AVAILABLE,
             "features": getattr(valuation_model, 'feature_columns', None)

--- a/valuation-api/models/ml_valuation_model.py
+++ b/valuation-api/models/ml_valuation_model.py
@@ -24,17 +24,6 @@ class MLValuationModel:
             'total_area', 'building_ratio', 'age_squared'
         ]
         
-        # 東京23区の基準価格（フォールバック用）
-        self.ward_base_prices = {
-            '千代田区': 250, '中央区': 200, '港区': 220,
-            '新宿区': 150, '文京区': 140, '台東区': 120,
-            '墨田区': 100, '江東区': 110, '品川区': 160,
-            '目黒区': 170, '大田区': 130, '世田谷区': 140,
-            '渋谷区': 180, '中野区': 120, '杉並区': 130,
-            '豊島区': 140, '北区': 100, '荒川区': 90,
-            '板橋区': 100, '練馬区': 110, '足立区': 80,
-            '葛飾区': 85, '江戸川区': 90
-        }
         
         self._load_model()
     
@@ -50,7 +39,8 @@ class MLValuationModel:
                 self.is_trained = True
                 logger.info("ML model loaded successfully")
             else:
-                logger.warning("ML model files not found, will use fallback method")
+                logger.error("ML model files not found - ML model is required")
+                raise FileNotFoundError("ML model files (valuation_model.joblib, label_encoders.joblib) not found")
                 
         except Exception as e:
             logger.error(f"Failed to load ML model: {e}")
@@ -105,30 +95,6 @@ class MLValuationModel:
             logger.error(f"Feature preparation failed: {e}")
             raise
     
-    def _fallback_prediction(self, prefecture: str, city: str, district: str,
-                           land_area: float, building_area: float, building_age: int) -> Dict[str, Any]:
-        """MLモデルが使用できない場合のフォールバック予測"""
-        logger.info("Using fallback rule-based prediction")
-        
-        # 基準価格を取得
-        base_price_per_sqm = self.ward_base_prices.get(city, 100)
-        
-        # 土地価格計算
-        land_price = land_area * base_price_per_sqm
-        
-        # 建物価格計算（築年数による減価）
-        building_depreciation = max(0.3, 1 - (building_age * 0.03))
-        building_price = building_area * base_price_per_sqm * 0.8 * building_depreciation
-        
-        # 総価格
-        total_price = (land_price + building_price) * 10000  # 万円から円に変換
-        
-        # 市場変動（±5%）
-        import random
-        variation = random.uniform(0.95, 1.05)
-        estimated_price = total_price * variation
-        
-        return estimated_price
     
     def predict(self, prefecture: str, city: str, district: str,
                 land_area: float, building_area: float, building_age: int) -> Dict[str, Any]:
@@ -147,30 +113,20 @@ class MLValuationModel:
             予測結果の辞書
         """
         try:
-            if self.is_trained and self.model is not None:
-                # ML予測を試行
-                try:
-                    X = self._prepare_features(prefecture, city, district, 
-                                             land_area, building_area, building_age)
-                    estimated_price = self.model.predict(X)[0]
-                    
-                    # 信頼度計算（MLモデルベース）
-                    confidence = max(75, min(95, 90 - building_age * 0.3))
-                    
-                    logger.info(f"ML prediction: ¥{estimated_price:,.0f}")
-                    
-                except Exception as e:
-                    logger.warning(f"ML prediction failed: {e}, using fallback")
-                    estimated_price = self._fallback_prediction(
-                        prefecture, city, district, land_area, building_area, building_age
-                    )
-                    confidence = max(70, min(85, 85 - building_age * 0.5))
-            else:
-                # フォールバック予測
-                estimated_price = self._fallback_prediction(
-                    prefecture, city, district, land_area, building_area, building_age
-                )
-                confidence = max(70, min(85, 85 - building_age * 0.5))
+            # MLモデルが利用可能かチェック
+            if not self.is_trained or self.model is None:
+                logger.error("ML model is not available")
+                raise RuntimeError("ML model is not loaded. Cannot perform valuation.")
+            
+            # ML予測を実行
+            X = self._prepare_features(prefecture, city, district, 
+                                     land_area, building_area, building_age)
+            estimated_price = self.model.predict(X)[0]
+            
+            # 信頼度計算（MLモデルベース）
+            confidence = max(75, min(95, 90 - building_age * 0.3))
+            
+            logger.info(f"ML prediction: ¥{estimated_price:,.0f}")
             
             # 価格帯計算
             price_range = {
@@ -179,12 +135,7 @@ class MLValuationModel:
             }
             
             # 査定要因分析
-            factors = []
-            
-            if self.is_trained:
-                factors.append("機械学習モデルによる高精度予測")
-            else:
-                factors.append("ルールベース予測（MLモデル未利用）")
+            factors = ["機械学習モデルによる高精度予測"]
             
             if building_age <= 5:
                 factors.append("築浅物件で、価格にプラス影響")


### PR DESCRIPTION
- LightweightValuationModelからルールベース計算を削除
- MLValuationModelのフォールバック処理を削除
- MLモデルが未ロードの場合は明示的にエラー（500）を返すように変更
- /api/model/infoのレスポンスから"Rule-based"表記を除去
- すべての査定処理をMLモデル専用に統合